### PR TITLE
Improved PHP sub-menu text

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,7 @@
                 "id": "CreateNewFilesJsFrameworkSubMenu"
             },
             {
-                "label": "🅿️ PHP Classes",
+                "label": "🅿️ PHP",
                 "id": "CreateNewFilesPHPClassesSubMenu"
             }
         ],


### PR DESCRIPTION
I think this is an improvement because the sub-menu is not only for making php classes. Also, this makes the name more similar to the "JS" sub-menu where it does not say "JS classes" or "JS files", but instead is simply an icon and "JS". In the context of the explorer, you have already selected "New", so I think this is intuitive because contextually it is then "New" -> "PHP" -> and a list of options.